### PR TITLE
KG - Query Name Fixes

### DIFF
--- a/app/views/query_names/index.js.coffee
+++ b/app/views/query_names/index.js.coffee
@@ -11,7 +11,9 @@ updateQueries = () ->
 
     $(this).selectpicker('refresh')
   <% else %>
-  $("select[name*=query_name]").parents('.dropdown').attr('data-toggle', 'tooltip').prop('title', I18n.t('requests.form.tooltips.no_i2b2_queries'))
+  $("select[name*=query_name]").parents('.dropdown').attr('data-toggle', 'tooltip').prop('title', "<%= t("requests.form.tooltips.no_i2b2_queries.#{params[:protocol_id].present? ? 'protocol' : 'user'}").html_safe %>")
+  $("select[name*=query_name] option:not(:first-child)").remove()
+  $("select[name*=query_name]").selectpicker('refresh')
   <% end %>
 
 updateQueries()

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -392,9 +392,11 @@ en:
         protocol: "Search for an existing Protocol in SPARCRequest"
         protocol_found: "Imported data from Study #%{id}"
         protocol_not_found: "Could not find a corresponding Study in SPARCRequest. Please fill in the information below to create a new Study"
-        i2b2_query: "Information about creating an i2b2 query can be found at <a href='http://academicdepartments.musc.edu/bmic/DataRequest.html' target='_blank'>http://academicdepartments.musc.edu/bmic/DataRequest.html</a>. Queries shown are populated from all SPARCRequest team members."
+        i2b2_query: "Information about creating an i2b2 query can be found at <a href='http://academicdepartments.musc.edu/bmic/DataRequest' target='_blank'>http://academicdepartments.musc.edu/bmic/DataRequest.html</a>. Queries shown are populated from all SPARC study team members."
       tooltips:
-        no_i2b2_queries: "You don't have any I2b2 Queries. I2b2 queries are required to find the right specimens for your Study."
+        no_i2b2_queries:
+          protocol: "None of this study's users have existing i2b2 queries. Please visit the link above to create queries so that we can find the right specimens for your study."
+          user: "You don't have any existing i2b2 queries. Please visit the link above to create queries so that we can find the right specimens for your study."
       alerts:
         permissions:
           title: "Invalid Permissions"


### PR DESCRIPTION
1. When no queries are found, the dropdowns should be cleared (besides the blank first option)
2. Because queries are populated under two scenarios: SPARC Study exists vs doesn't exist, I made two separate tooltips and also improved the tooltip language a bit